### PR TITLE
Add hideDownloadButton to Options

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -227,6 +227,12 @@ declare namespace PhotoSwipe {
         mouseUsed?: boolean;
 
         /**
+         * A boolean that indicates whether the download button should be hidden. Download button is shown by default.
+         */
+        hideDownloadButton?: boolean;
+        /**
+
+        /**
          * esc keyboard key to close PhotoSwipe. Option can be changed dynamically (yourPhotoSwipeInstance.options.escKey = false;).
          *
          * Default true.


### PR DESCRIPTION
Add hideDownloadButton to Options to allow hiding the button in certain instances when download is unavailable. (Otherwise, the button is visible but performs no action)

More details provided in MSFT internal chat thread.